### PR TITLE
Krav Maga martial extension additions

### DIFF
--- a/BL9-100%-monster-resilience-version/Items/martial_extension.json
+++ b/BL9-100%-monster-resilience-version/Items/martial_extension.json
@@ -55,7 +55,13 @@
         "BL9_claws_evo",
         "BL9_spiked_sledgehammer",
         "BL9_tentacle_axe_enhanced",
-        "BL9_claws_evo_enhanced"
+        "BL9_claws_evo_enhanced",
+        "BL9_pistol",
+        "BL9_auto",
+        "BL9_pistol_mk2",
+        "BL9_auto_mk2",
+        "BL9_pistol_mk3",
+        "BL9_auto_mk3"
       ]
     }
   },

--- a/BL9-140%-monster-resilience-version/Items/martial_extension.json
+++ b/BL9-140%-monster-resilience-version/Items/martial_extension.json
@@ -55,7 +55,13 @@
         "BL9_claws_evo",
         "BL9_spiked_sledgehammer",
         "BL9_tentacle_axe_enhanced",
-        "BL9_claws_evo_enhanced"
+        "BL9_claws_evo_enhanced",
+        "BL9_pistol",
+        "BL9_auto",
+        "BL9_pistol_mk2",
+        "BL9_auto_mk2",
+        "BL9_pistol_mk3",
+        "BL9_auto_mk3"
       ]
     }
   },

--- a/BL9-175%-monster-resilience-version/Items/martial_extension.json
+++ b/BL9-175%-monster-resilience-version/Items/martial_extension.json
@@ -55,7 +55,13 @@
         "BL9_claws_evo",
         "BL9_spiked_sledgehammer",
         "BL9_tentacle_axe_enhanced",
-        "BL9_claws_evo_enhanced"
+        "BL9_claws_evo_enhanced",
+        "BL9_pistol",
+        "BL9_auto",
+        "BL9_pistol_mk2",
+        "BL9_auto_mk2",
+        "BL9_pistol_mk3",
+        "BL9_auto_mk3"
       ]
     }
   },


### PR DESCRIPTION
Added BL9 handguns and rifles as valid weapons for Krav Maga martial style as for CDDA is builded around allowing those types of firearms as valid weapons for this particular martial style.